### PR TITLE
Add support for sequenceable callable classes

### DIFF
--- a/lib/redux_thunk.dart
+++ b/lib/redux_thunk.dart
@@ -1,5 +1,6 @@
 library redux_thunk;
 
+import 'dart:async';
 import 'package:redux/redux.dart';
 
 /// The thunkMiddleware intercepts and calls [ThunkAction]s, which is simply a
@@ -36,13 +37,18 @@ import 'package:redux/redux.dart';
 ///
 ///      store.dispatch(searchResults);
 ///    };
-void thunkMiddleware<State>(
-  Store<State> store,
+void thunkMiddleware<State>(Store<State> store,
   dynamic action,
-  NextDispatcher next,
-) {
+  NextDispatcher next,) async {
   if (action is ThunkAction<State>) {
     action(store);
+  } else if (action is ThunkCallableAction) {
+    try {
+      dynamic result = await action.call(store);
+      action._completer.complete(result);
+    } catch (e) {
+      action._completer.completeError(e);
+    }
   } else {
     next(action);
   }
@@ -52,6 +58,30 @@ void thunkMiddleware<State>(
 /// intercepted by the the [thunkMiddleware]. It can be used to delay the
 /// dispatch of an action, or to dispatch only if a certain condition is met.
 ///
-/// The ThunkFunction receives a [Store], which it can use to get the latest
+/// The ThunkAction receives a [Store], which it can use to get the latest
 /// state if need be, or dispatch actions at the appropriate time.
 typedef void ThunkAction<State>(Store<State> store);
+
+/// A base class that can be used to build a callable class that can be
+/// dispatched as an action to a Redux [Store] and intercepted by the the
+/// [thunkMiddleware]. It can be used to delay the dispatch of an action, or to
+/// dispatch only if a certain condition is met.
+///
+/// The ThunkCallableAction's [call] function receives a [Store], which it can
+/// use to get the latest state if need be, or dispatch actions at the
+/// appropriate time.
+///
+/// The ThunkCallableAction also exposes an [onComplete] property which returns
+/// a [Future] that is completed based on the result of the [call] function.
+/// This property can be used to trigger asynchronous actions in a sequence.
+abstract class ThunkCallableAction<State> {
+  final Completer _completer = Completer<dynamic>();
+
+  /// The function that receives the [Store] for retrieving state and
+  /// dispatching actions.
+  FutureOr call(Store<State> store);
+
+  /// A [Future] that is completed once the result of calling [call] is
+  /// available.
+  Future get onComplete => _completer.future;
+}

--- a/test/redux_thunk_test.dart
+++ b/test/redux_thunk_test.dart
@@ -48,5 +48,58 @@ void main() {
         completion(dispatchedAction),
       );
     });
+
+    group('ThunkCallableAction', () {
+      test('dispatches successfully when no error thrown', () async {
+        final store = new Store<String>(
+          identityReducer,
+          middleware: [thunkMiddleware],
+        );
+
+        final dispatchValue = "Friend";
+        var action = new TestAction(dispatchValue);
+        store.dispatch(action);
+
+        expect(store.state, dispatchValue);
+
+        String onCompleteValue = await action.onComplete;
+        expect(onCompleteValue, dispatchValue);
+      });
+
+      test('completes the onComplete future with an error when one occurs', () async {
+        final store = new Store<String>(
+          identityReducer,
+          middleware: [thunkMiddleware],
+        );
+
+        var action = new TestErrorAction();
+        store.dispatch(action);
+
+        expect(store.state, null);
+
+        expect(action.onComplete, throwsException);
+      });
+    });
   });
+}
+
+class TestAction extends ThunkCallableAction<String> {
+  final String value;
+
+  TestAction(this.value);
+
+  @override
+  FutureOr call(Store<String> store) async {
+    store.dispatch(value);
+    return value;
+  }
+}
+
+class TestErrorAction extends ThunkCallableAction<String> {
+  TestErrorAction();
+
+  @override
+  FutureOr call(Store<String> store) async {
+    throw Exception('Oh noes!');
+  }
 }


### PR DESCRIPTION
This resolves issue #12 and provides a built-in workaround
for brianegan/flutter_redux#65